### PR TITLE
Fix 2 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-core</artifactId>
-            <version>2.5.25</version>
+            <version>6.3.0.2</version>
         </dependency>
         <!--vulnerable dependency end-->
 

--- a/backend-app/pom.xml
+++ b/backend-app/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.17.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
         <dependency>


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Wed, 17 Jan 2024 10:27:12 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | app/pom.xml | org.apache.struts_struts2-core | [CVE-2023-50164](https://nvd.nist.gov/vuln/detail/CVE-2023-50164) | 9.8 | fixed in 6.3.0.2, 2.5.33 | An attacker can manipulate file upload params to enable paths traversal and under some circumstances this can lead to uploading a malicious file which can be used to perform Remote Code Execution. Users are recommended to upgrade to versions Struts 2.5.33 or Struts 6.3.0.2 or greater tou00a0fix this issue. 
critical | app/pom.xml | org.apache.struts_struts2-core | [CVE-2020-17530](https://nvd.nist.gov/vuln/detail/CVE-2020-17530) | 9.8 | fixed in 2.5.30 | Forced OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution. Affected software : Apache Struts 2.0.0 - Struts 2.5.25.
critical | app/pom.xml | org.apache.struts_struts2-core | [CVE-2021-31805](https://nvd.nist.gov/vuln/detail/CVE-2021-31805) | 9.8 | fixed in 2.5.30 | The fix issued for CVE-2020-17530 was incomplete. So from Apache Struts 2.0.0 to 2.5.29, still some of the tag’s attributes could perform a double evaluation if a developer applied forced OGNL evaluation by using the %{...} syntax. Using forced OGNL evaluation on untrusted user input can lead to a Remote Code Execution and security degradation.
critical | backend-app/pom.xml | org.apache.logging.log4j_log4j-core | [CVE-2021-44228](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44228) | 10.0 | fixed in 2.15.0, 2.12.2 | Apache Log4j2 2.0-beta9 through 2.15.0 (excluding security releases 2.12.2, 2.12.3, and 2.3.1) JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. From version 2.16.0 (along with 2.12.2, 2.12.3, and 2.3.1), this functionality has been completely removed. Note that this vulnerability is specific to log4j-core and does not affect log4net, log4cxx, or other Apache Logging Services projects.
critical | backend-app/pom.xml | org.apache.logging.log4j_log4j-core | [CVE-2021-45046](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046) | 9.0 | fixed in 2.16.0, 2.12.2, 2.3.1 | It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allows attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in an information leak and remote code execution in some environments and local code execution in all environments. Log4j 2.16.0 (Java 8) and 2.12.2 (Java 7) fix this issue by removing support for message lookup patterns and disabling JNDI functionality by default.
high | app/pom.xml | org.apache.struts_struts2-core | [CVE-2023-41835](https://nvd.nist.gov/vuln/detail/CVE-2023-41835) | 7.5 | fixed in 6.3.0.1, 2.5.32 | When a Multipart request is performed but some of the fields exceed the maxStringLengthu00a0 limit, the upload files will remain in struts.multipart.saveDiru00a0 even if the request has been denied. Users are recommended to upgrade to versions Struts 2.5.32 or 6.1.2.2 or Struts 6.3.0.1 or greater, which fixe this issue.
high | app/pom.xml | org.apache.struts_struts2-core | [CVE-2023-34396](https://nvd.nist.gov/vuln/detail/CVE-2023-34396) | 7.5 | fixed in 6.1.2.1, 2.5.31 | Allocation of Resources Without Limits or Throttling vulnerability in Apache Software Foundation Apache Struts.This issue affects Apache Struts: through 2.5.30, through 6.1.2.  Upgrade to Struts 2.5.31 or 6.1.2.1 or greater   
high | backend-app/pom.xml | org.apache.logging.log4j_log4j-core | [CVE-2021-45105](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45105) | 7.5 | fixed in 2.17.0, 2.12.3, 2.3.1 | Apache Log4j2 versions 2.0-alpha1 through 2.16.0 (excluding 2.12.3 and 2.3.1) did not protect from uncontrolled recursion from self-referential lookups. This allows an attacker with control over Thread Context Map data to cause a denial of service when a crafted string is interpreted. This issue was fixed in Log4j 2.17.0, 2.12.3, and 2.3.1.
medium | app/pom.xml | org.apache.struts_struts2-core | [CVE-2023-34149](https://nvd.nist.gov/vuln/detail/CVE-2023-34149) | 6.5 | fixed in 6.1.2.1, 2.5.31 | Allocation of Resources Without Limits or Throttling vulnerability in Apache Software Foundation Apache Struts.This issue affects Apache Struts: through 2.5.30, through 6.1.2.  Upgrade to Struts 2.5.31 or 6.1.2.1 or greater.   
medium | backend-app/pom.xml | org.apache.logging.log4j_log4j-core | [CVE-2021-44832](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832) | 6.6 | fixed in 2.17.1, 2.12.4, 2.3.2 | Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding security fix releases 2.3.2 and 2.12.4) are vulnerable to a remote code execution (RCE) attack when a configuration uses a JDBC Appender with a JNDI LDAP data source URI when an attacker has control of the target LDAP server. This issue is fixed by limiting JNDI data source names to the java protocol in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2.
